### PR TITLE
Simplify Test Suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,6 @@ group :development, :test do
   # JavScript unit test lirbrary
   gem 'jasmine'
 
-  # stub HTTP requests
-  gem 'webmock'
-
   # Ruby task runner
   gem 'rb-fsevent'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.5)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     chunky_png (1.2.9)
@@ -10,8 +9,6 @@ GEM
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
-    crack (0.4.1)
-      safe_yaml (~> 0.9.0)
     daemons (1.1.9)
     diff-lcs (1.2.5)
     em-websocket (0.5.0)
@@ -78,7 +75,6 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    safe_yaml (0.9.7)
     sass (3.2.12)
     sinatra (1.4.4)
       rack (~> 1.4)
@@ -92,9 +88,6 @@ GEM
     thor (0.18.1)
     tilt (1.4.1)
     timers (1.1.0)
-    webmock (1.16.1)
-      addressable (>= 2.2.7)
-      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
@@ -111,4 +104,3 @@ DEPENDENCIES
   rspec
   sinatra
   thin
-  webmock

--- a/spec/emoticon_spec.rb
+++ b/spec/emoticon_spec.rb
@@ -10,27 +10,4 @@ describe 'Helpers::HipChat' do
       Helpers::HipChat.base_uri.should eql 'https://api.hipchat.com/v2'
     end
   end
-
-  describe '.get_emoticons' do
-    it 'makes a successful GET request' do
-      hipchat = Helpers::HipChat.new
-      hipchat.get_emoticons.response.code.should eql "200"
-    end
-  end
-end
-
-describe 'Helpers.all_emoticons' do
-  it 'returns a hash' do
-    all_emoticons.class.should eql String
-  end
-end
-
-describe 'Emoticon external request' do
-  it 'queries the HipChat API' do
-    uri = URI("https://api.hipchat.com/v2#{ENV['HIPCHAT_API']}")
-
-    response = Net::HTTP.get(uri)
-
-    expect(response).to be_an_instance_of(String)
-  end
 end

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -11,4 +11,3 @@ describe 'This Sinatra application' do
     last_response.status.should == 404
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'rack/test'
-require 'webmock/rspec'
 require_relative '../app.rb'
 
 set :environment, :test
@@ -13,12 +12,4 @@ end
 RSpec.configure do |c|
   c.include Rack::Test::Methods
   c.include RSpecHelper
-  c.before(:each) do
-    stub_request(:get, "https://api.hipchat.com/v2/emoticon?auth_token=#{ENV['HIPCHAT_API']}").
-    with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'api.hipchat.com', 'User-Agent'=>'Ruby'}).
-    to_return(:status => 200, :body => "stubbed response", :headers => {})
-  end
 end
-
-# Prevent test suite from making external HTTP requests
-WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Removes `webmock` and unnecessary tests calling an external API.
